### PR TITLE
The onValidatonError callback does not contain details specifics to the validation errors

### DIFF
--- a/src/server/decorate-express-router.ts
+++ b/src/server/decorate-express-router.ts
@@ -23,7 +23,7 @@ export interface DecorateExpressRouterOptions<Schema extends HttpSchema, App ext
      * Optional request handler to delegate to if a server-side validation error occurs. If this option is not
      * specified, the default behaviour is to respond with a 400 status code.
      */
-    onValidationError?: ExpressRequestHandler;
+    onValidationError?: ErrorRequestHandler;
 }
 
 
@@ -110,8 +110,8 @@ function createRequestPropValidationMiddleware(requestProps: TypeInfo): ExpressR
 
 
 /** Creates a middleware function that validates request params/body and response body for the given `routeInfo`. */
-function createBodyValidationMiddleware(routeInfo: HttpSchema[any], onValidationError?: ExpressRequestHandler): ExpressRequestHandler {
-    onValidationError = onValidationError ?? ((_, res) => {
+function createBodyValidationMiddleware(routeInfo: HttpSchema[any], onValidationError?: ErrorRequestHandler): ExpressRequestHandler {
+    onValidationError = onValidationError ?? ((err, _, res) => {
         res.status(400).send('The request body did not conform to the required schema.');
     });
 

--- a/src/server/decorate-express-router.ts
+++ b/src/server/decorate-express-router.ts
@@ -142,7 +142,7 @@ function createBodyValidationMiddleware(routeInfo: HttpSchema[any], onValidation
             req.body = validateAndClean(req.body, routeInfo.requestBody ?? t.object({}));
         }
         catch (err) {
-            onValidationError!(req, res, next);
+            onValidationError!(err, req, res, next);
             return;
         }
 

--- a/src/test/fixtures/test-server.ts
+++ b/src/test/fixtures/test-server.ts
@@ -26,7 +26,8 @@ export function createTestServer() {
     const typedRoutes = decorateExpressRouter({
         schema: testSchema,
         requestProps: RequestProps,
-        onValidationError: (_, res) => {
+        onValidationError: (err, _, res) => {
+            console.log(err);
             res.status(200).send({success: false, code: 'MY_CUSTOM_VALIDATION_ERROR'});
         },
     });
@@ -40,12 +41,12 @@ export function createTestServer() {
             Math.random(),
         ]);
     });
-    
+
     typedRoutes.post('/sum', [log], (req, res) => {
         let result = req.body.reduce((sum, n) => sum + n, 0);
         res.send(result);
     });
-    
+
     // Specify some route handlers separately and then add them to the app.
     const handleProduct = createRequestHandler({
         schema: testSchema,


### PR DESCRIPTION
- Changed the type of the `onValidationError` callback from `ExpressRequestHandler` to `ErrorRequestHandler`
- Pass the error object as the first param to the `onValidationError` function
- Update the unit test to log the received error object

Issue: https://github.com/yortus/http-schemas/issues/2