### PR TITLE
Add a link to the demo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ apiRouter.post('/sum', (req, res) => { res.send('foo') });  // tsc build error &
 
 app.listen(8000);
 ```
+
+## Full production-like webserver demo
+
+The best way to see `http-schemas` in action is to see it in a real demonstration with documentation. Take a look at [http-schemas-webserver-demo](https://github.com/Antman261/http-schemas-webserver-demo), read the docs, run it and play with it yourself.


### PR DESCRIPTION
I created a demo of http-schemas with a full client and web server for my talk, with decent documentation.

I thought it might be cool to link to it from the README