### PR TITLE
Fix #11: Enable http-schemas to work without json parser

### DIFF
--- a/src/server/decorate-express-router.ts
+++ b/src/server/decorate-express-router.ts
@@ -138,8 +138,7 @@ function createBodyValidationMiddleware(routeInfo: HttpSchema[any], onValidation
         // having an invalid request structure signifies a client error.
         try {
             // TODO: test that this actually replaces the req.body value
-            // TODO: doc that req.body will always be an empty object, and not undefined, if no body was sent
-            req.body = validateAndClean(req.body, routeInfo.requestBody ?? t.object({}));
+            req.body = validateAndClean(req.body, routeInfo.requestBody ?? t.union(t.object({}), t.undefined));
         }
         catch (err) {
             onValidationError!(err, req, res, next);

--- a/src/test/client-server.test.ts
+++ b/src/test/client-server.test.ts
@@ -1,44 +1,54 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import {createTestClient} from './fixtures/test-client';
-import {createTestServer} from './fixtures/test-server';
+import {createGetOnlyServer, createTestServer} from './fixtures/test-server';
 
 
 chai.use(chaiAsPromised);
 const {expect} = chai;
 
 
-let client = createTestClient();
-let server = createTestServer();
-before(server.start);
-after(server.stop);
-
-
 describe('Implementing a HTTP client and server', () => {
-
+    const client = createTestClient();
+    const server = createTestServer();
+    before(server.start);
+    after(server.stop);
     it('GET /random-numbers', async () => {
-        let rnds = await client.get('/random-numbers');
+        const rnds = await client.get('/random-numbers');
         expect(rnds).to.be.an('array');
         rnds.every(n => expect(n).to.be.a('number'));
     });
     it('POST /add', async () => {
-        let sum = await client.post('/sum', {body: [1, 2, 3, 4]});
+        const sum = await client.post('/sum', {body: [1, 2, 3, 4]});
         expect(sum).equals(10);
     });
     it('POST /product', async () => {
-        let prod = await client.post('/product', {body: [10, 20, 30, 40]});
+        const prod = await client.post('/product', {body: [10, 20, 30, 40]});
         expect(prod).equals(240_000);
     });
     it('GET *', async () => {
-        let msg = await client.get('*', {params: {0: '/hello'}, body: {name: 'foo'}});
+        const msg = await client.get('*', {params: {0: '/hello'}, body: {name: 'foo'}});
         expect(msg).equals('Hello, foo!');
     });
     it('GET * (invalid)', async () => {
-        let getMsg = () => client.get('*', {params: {0: '/ciao'}, body: {name: 'bella'}});
+        const getMsg = () => client.get('*', {params: {0: '/ciao'}, body: {name: 'bella'}});
         await expect(getMsg()).to.eventually.be.rejected;
     });
     it('Server-side validation error', async () => {
-        let invalid = await client.post('/sum', {body: [1, '2', 3, 4] as number[]});
+        const invalid = await client.post('/sum', {body: [1, '2', 3, 4] as number[]});
         expect(invalid).to.include({success: false, code: 'MY_CUSTOM_VALIDATION_ERROR'});
     });
 });
+
+describe('HTTP Server without JSON parser', () => {
+    const client = createTestClient();
+    const server = createGetOnlyServer();
+    before(server.start);
+    after(server.stop);
+
+    it('GET /random-numbers works without json body parser', async () => {
+        const rnds = await client.get('/random-numbers');
+        expect(rnds).to.be.an('array');
+        rnds.every(n => expect(n).to.be.a('number'));
+    });
+})

--- a/src/test/fixtures/test-schema.ts
+++ b/src/test/fixtures/test-schema.ts
@@ -27,3 +27,12 @@ export const testSchema = createHttpSchema([
         responseBody: t.unknown,
     }),
 ]);
+
+export const testGetOnlySchema = createHttpSchema([
+  // Used for testing get request without json body parser
+    createHttpRoute({
+        method: 'GET',
+        path: '/random-numbers',
+        responseBody: t.array(t.number),
+    }),
+])


### PR DESCRIPTION
* GET routes without a body can match empty object or undefined
* Improves developer experience when building an app without need for json parser