### PR TITLE
Add support for `put` request

### DIFF
--- a/src/client/create-http-client.ts
+++ b/src/client/create-http-client.ts
@@ -18,11 +18,12 @@ export function createHttpClient<S extends HttpSchema>(schema: S, options?: Part
     let result: HttpClient<S> = {
         get: (path, info?) => request('GET', path, info),
         post: (path, info?) => request('POST', path, info),
+        put: (path, info?) => request('PUT', path, info),
     };
     return result;
 
     // This function makes the actual HTTP requests through axios.
-    async function request(method: 'GET' | 'POST', path: string, info?: {params?: any, body?: any}) {
+    async function request(method: 'GET' | 'POST' | 'PUT', path: string, info?: {params?: any, body?: any}) {
 
         // Create the actual URL by substituting params (if any) into the path pattern.
         // NB: what axios calls `params` are really queryparams, so different from our `params`,
@@ -79,11 +80,17 @@ export type HttpClient<S extends HttpSchema> = {
             ? [RequestInfo<S, 'POST', P>?]  // make the `info` arg optional if this route has no params/body
             : [RequestInfo<S, 'POST', P>]   // make the `info` arg required if this route does have params/body
     ): Promise<ResponseBody<S, 'POST', P>>;
+    put<P extends Paths<S, 'PUT'>>(
+        path: P,
+        ...info: HasParamsOrBody<S, 'PUT', P> extends false
+            ? [RequestInfo<S, 'PUT', P>?]  // make the `info` arg optional if this route has no params/body
+            : [RequestInfo<S, 'PUT', P>]   // make the `info` arg required if this route does have params/body
+    ): Promise<ResponseBody<S, 'PUT', P>>;
 };
 
 
 /** Strongly-typed object used to provide details for a HTTP request to a specific route. */
-type RequestInfo<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path'] = string> =
+type RequestInfo<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path'] = string> =
     & (HasParams<S, M, P> extends true
         ? {params: Record<ParamNames<S, M, P>, string>} // make `params` requierd if this route does have params
         : {params?: Record<string, never>})             // make `params` optional if this route has no params
@@ -93,15 +100,15 @@ type RequestInfo<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any
 
 
 /** Helper type that resolves to `true` if the route for the given method/path has defined paramNames. */
-type HasParams<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path']>
+type HasParams<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path']>
     = ParamNames<S, M, P> extends never ? false : true;
 
 
 /** Helper type that resolves to `true` if the route for the given method/path has defined requestBody. */
-type HasBody<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path']>
+type HasBody<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path']>
     = RequestBody<S, M, P> extends undefined ? false : true;
 
 
 /** Helper type that resolves to `true` if the route for the given method/path has paramNames and/or requestBody. */
-type HasParamsOrBody<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path']>
+type HasParamsOrBody<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path']>
     = HasParams<S, M, P> extends true ? true : HasBody<S, M, P>;

--- a/src/server/create-request-handler.ts
+++ b/src/server/create-request-handler.ts
@@ -9,13 +9,13 @@ import {HttpSchema} from '../shared';
  * Accepts and returns a request handler function that is strongly-typed to match the given schema definition for the
  * given method and path. The function is returned as-is. This helper just provides convenient contextual typing.
  */
-export function createRequestHandler<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path']>(
+export function createRequestHandler<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path']>(
     schema: S,
     method: M,
     path: P,
     handler: RequestHandler<S, M, P, {}>
 ): RequestHandler<S, M, P, {}>;
-export function createRequestHandler<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path'], ReqProps extends TypeInfo = t.object>(
+export function createRequestHandler<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path'], ReqProps extends TypeInfo = t.object>(
     options: {
         schema: S,
         method: M,
@@ -40,12 +40,12 @@ export function createRequestHandler(optionsOrSchema: unknown, method?: unknown,
 
 
 /** A strongly-typed express request handler. */
-export type RequestHandler<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path'], Req> =
+export type RequestHandler<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path'], Req> =
     (req: TypedRequest<S, M, P, Req>, res: TypedResponse<S, M, P>, next: NextFunction) => void | Promise<void>;
 
 
 /** A strongly-typed express request. Some original props are omited and replaced with typed ones. */
-type TypedRequest<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path'], Req> =
+type TypedRequest<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path'], Req> =
 Omit<Request<Record<ParamNames<S, M, P>, string>>, 'body'>
 & Req
 & {
@@ -55,7 +55,7 @@ Omit<Request<Record<ParamNames<S, M, P>, string>>, 'body'>
 
 
 /** A strongly-typed express response. Some original props are omited and replaced with typed ones. */
-type TypedResponse<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path']> =
+type TypedResponse<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path']> =
 Omit<Response, 'end' | 'json' | 'jsonp' | 'send' | 'status'> & {
     end: never;
     json: (body: ResponseBody<S, M, P>) => TypedResponse<S, M, P>;

--- a/src/shared/create-http-route.ts
+++ b/src/shared/create-http-route.ts
@@ -3,7 +3,7 @@ import {RouteInfo} from './route-info';
 
 /** Convenience function for defining a single route within a HTTP schema. */
 export function createHttpRoute<
-    M extends 'GET' | 'POST',
+    M extends 'GET' | 'POST' | 'PUT',
     P extends string,
     N extends string,
     T extends RouteInfo<M, P, N>

--- a/src/shared/create-http-schema.ts
+++ b/src/shared/create-http-schema.ts
@@ -40,4 +40,4 @@ export function createHttpSchema<T extends HttpSchema>(schema: T) {
 
 
 /** A HTTP Schema, which is an array of `RouteInfo` items. */
-export type HttpSchema = RouteInfo<'GET' | 'POST', string, string>[];
+export type HttpSchema = RouteInfo<'GET' | 'POST' | 'PUT', string, string>[];

--- a/src/shared/route-info.ts
+++ b/src/shared/route-info.ts
@@ -2,7 +2,7 @@ import {TypeInfo} from 'rtti';
 
 
 /** Runtime type information about a single HTTP route. */
-export interface RouteInfo<M extends 'GET' | 'POST', P extends string, N extends string> {
+export interface RouteInfo<M extends 'GET' | 'POST' | 'PUT', P extends string, N extends string> {
     method: M;
     path: P;
     paramNames?: N[];

--- a/src/test/client-server.test.ts
+++ b/src/test/client-server.test.ts
@@ -34,6 +34,10 @@ describe('Implementing a HTTP client and server', () => {
         const getMsg = () => client.get('*', {params: {0: '/ciao'}, body: {name: 'bella'}});
         await expect(getMsg()).to.eventually.be.rejected;
     });
+    it('PUT /multiply', async () => {
+        const prod = await client.put('/multiply', {body: {first: 2, second:5}});
+        expect(prod).equals(10);
+    });
     it('Server-side validation error', async () => {
         const invalid = await client.post('/sum', {body: [1, '2', 3, 4] as number[]});
         expect(invalid).to.include({success: false, code: 'MY_CUSTOM_VALIDATION_ERROR'});

--- a/src/test/fixtures/readme-example.ts
+++ b/src/test/fixtures/readme-example.ts
@@ -15,6 +15,15 @@ const apiSchema = createHttpSchema([
         paramNames: ['name'],
         responseBody: t.string,
     }),
+    createHttpRoute({
+        method: 'PUT',
+        path: '/multiply',
+        requestBody: t.object({
+            first: t.number,
+            second: t.number
+        }),
+        responseBody: t.number,
+    }),
 ]);
 
 
@@ -29,6 +38,7 @@ const client = createHttpClient(apiSchema, {baseURL: '/api'});
 // Some valid request examples
 let res1 = client.post('/sum', {body: [1, 2]});                 // res1: Promise<number>
 let res2 = client.get('/greet/:name', {params: {name: 'Bob'}}); // res2: Promise<string>
+let res3 = client.put('/multiply', {body: {first: 2, second: 5}});                 // res1: Promise<number>
 
 // Some invalid request examples
 //let res3 = client.get('/sum', {body: [1, 2]});                  // tsc build error & runtime error
@@ -61,6 +71,12 @@ const greetHandler = createRequestHandler(apiSchema, 'GET', '/greet/:name', (req
     res.send(`Hello, ${req.params.name}!`);
 });
 apiRouter.get('/greet/:name', greetHandler);
+
+apiRouter.put('/multiply', (req, res) => {
+    const {first, second} = req.body;
+    const result = first * second;
+    res.send(result);
+});
 
 // Some invalid route handler examples
 //apiRouter.post('/blah', (req, res) => {/*...*/});           // tsc build error & runtime error

--- a/src/test/fixtures/test-schema.ts
+++ b/src/test/fixtures/test-schema.ts
@@ -26,6 +26,12 @@ export const testSchema = createHttpSchema([
         requestBody: t.object({name: t.string}),
         responseBody: t.unknown,
     }),
+    createHttpRoute({
+        method: 'PUT',
+        path: '/multiply',
+        requestBody: t.object({first: t.number, second: t.number}),
+        responseBody: t.number,
+    }),
 ]);
 
 export const testGetOnlySchema = createHttpSchema([

--- a/src/test/fixtures/test-server.ts
+++ b/src/test/fixtures/test-server.ts
@@ -67,7 +67,19 @@ export function createTestServer() {
             res.status(500).send('Server error');
         }
     });
+    const handleMultiply = createRequestHandler({
+        schema: testSchema,
+        method: 'PUT',
+        path: '/multiply',
+        requestProps: RequestProps,
+        handler: (req, res) => {
+            const {first, second} = req.body;
+            const result = first * second;
+            res.send(result);
+        }
+    });
     typedRoutes.post('/product', [log], handleProduct);
+    typedRoutes.put('/multiply', [log], handleMultiply);
     typedRoutes.get('*', [log], handleWildcard);
 
     // Create an Express Application and add middleware to it, including our HTTP schema implementation.

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,28 +3,28 @@ import {HttpSchema} from './shared';
 
 
 /** Extracts the union of string literal paths for the given schema and method. */
-export type Paths<S extends HttpSchema, M extends 'GET' | 'POST'> = FilterRoutes<S, M, string>['path'];
+export type Paths<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT'> = FilterRoutes<S, M, string>['path'];
 
 
 /** Extracts the union of string literal param names for the given schema/method/path, or never if no params. */
-export type ParamNames<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path']>
+export type ParamNames<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path']>
     = FilterRoutes<S, M, P>['paramNames'] extends Array<infer U> ? Extract<U, string> : never;
 
 
 /** Extracts the request body type for the given schema/method/path, or undefined if no body type specified. */
-export type RequestBody<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path']>
+export type RequestBody<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path']>
     = FilterRoutes<S, M, P>['requestBody'] extends infer U
         ? U extends TypeInfo ? TypeFromTypeInfo<U> : undefined
         : never;
 
 
 /** Extracts the response body type for the given schema/method/path, or undefined if no body type specified. */
-export type ResponseBody<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path']>
+export type ResponseBody<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path']>
     = FilterRoutes<S, M, P>['responseBody'] extends infer U
         ? U extends TypeInfo ? TypeFromTypeInfo<U> : undefined
         : never;
 
 
 /** Helper mapped type that selects the (should be single) RouteInfo matching the given method/path. */
-type FilterRoutes<S extends HttpSchema, M extends 'GET' | 'POST', P extends S[any]['path']>
+type FilterRoutes<S extends HttpSchema, M extends 'GET' | 'POST' | 'PUT', P extends S[any]['path']>
     = S[any] extends infer U ? (U extends {method: M, path: P} ? U : never) : never;


### PR DESCRIPTION
- Update `RouteInfo` to contain `PUT` method type
- Update all types (such as `RequestHandler`, `TypedRequest` etc.) to contain `PUT` method type
- Implement `put` methods for `create-http-client` and `decorate-express-router`
- Update tests